### PR TITLE
Catch closed port message

### DIFF
--- a/lib/execjs.ex
+++ b/lib/execjs.ex
@@ -53,6 +53,7 @@ defmodule Execjs do
         loop(port, acc <> data)
       { ^port, :eof } ->
         send port, { self, :close }
+        receive do: ({ ^port, :closed } -> :ok)
         acc
     end
   end


### PR DESCRIPTION
Otherwise it produce closed message, which should caller catch.