### PR TITLE
Fix unknown error

### DIFF
--- a/lib/execjs.ex
+++ b/lib/execjs.ex
@@ -75,7 +75,7 @@ defmodule Execjs do
       [ "err", message ] ->
         raise %RuntimeError{message: message}
       [ "err" ] ->
-        raise %Error{}
+        raise %Error{message: "Unknown error"}
     end
   end
 end


### PR DESCRIPTION
If you trigger the last condition, Elixir raises an exception since %Error expects a message to be passed in.