### PR TITLE
Use nouse_stdio to avoid console.log pollution from destroying json response payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ best runtime available on the system.
 Use the application environment (application key: `:execjs`, key: `:runtime`)
 to set the runtime `Execjs` uses. Alternatively, the `EXECJS_RUNTIME`
 environment variable can also be used to set the runtime.
+### Additional Runtimes
+
+It is possible to define a custom runtime to specify an exact path
+to your runtime command:
+
+```elixir
+defmodule ServeElmWeb.Runtime do
+	import Execjs.Runtime
+
+	defruntime Node8,
+    		command: "/Users/o_o/.nvm/versions/node/v8.9.3/bin/node",
+		runner: "node_runner.js.eex"
+end
+
+```
+
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It is possible to define a custom runtime to specify an exact path
 to your runtime command:
 
 ```elixir
-defmodule ServeElmWeb.Runtime do
+defmodule MyModule.Runtime do
 	import Execjs.Runtime
 
 	defruntime Node8,

--- a/lib/execjs.ex
+++ b/lib/execjs.ex
@@ -35,7 +35,7 @@ defmodule Execjs do
 
     try do
       port = Port.open({ :spawn_executable, command },
-        [:stream, :in, :binary, :eof, :hide, { :args, [tmpfile] }])
+        [:stream, :in, :binary,:nouse_stdio, :eof, :hide, { :args, [tmpfile] }])
 
       extract_result(loop(port))
     after

--- a/priv/node_runner.js.eex
+++ b/priv/node_runner.js.eex
@@ -1,19 +1,24 @@
-(function(program, runner) { runner(program); })(function() {
-  return <%= source %>;
-}, function(program) {
-  var result;
-  try {
-    result = program();
-    try {
-      if (result === undefined) {
-        process.stdout.write('["ok"]');
-      } else {
-        process.stdout.write(JSON.stringify(['ok', result]));
-      }
-    } catch (err) {
-      process.stdout.write('["err"]');
+const fs = require('fs');
+(function(program, runner) {
+    runner(program);
+})(
+    function() {
+        return <%= source %>;
     }
-  } catch (err) {
-    process.stdout.write(JSON.stringify(['err', '' + err]));
-  }
-});
+    , async function(program) {
+        let result;
+        try {
+            result = await program();
+            try {
+                if (result === undefined) {
+                    fs.writeSync(4,'["ok"]');
+                } else {
+                    fs.writeSync(4,JSON.stringify(['ok', result]));
+                }
+            } catch (err) {
+               fs.writeSync(4, '["err"]');
+            }
+        } catch (err) {
+            fs.writeSync(4,JSON.stringify(['err', '' + err]));
+        }
+    });


### PR DESCRIPTION
Hello Mr Devinus,

I have used your library with some good effect in a proof of concept project at https://github.com/robotarmy/serve_elm.

I wonder if you would consider discussing these changes and perhaps exposing configuration for enabling other options for Port.open.. 

I use nouse_stdio to avoid console.log statements from becoming part of the output from your wrapper script.

I think their could be some cause for exposing the working directory option for the command to Port.open and also perhaps the ENV option.

Any thoughts?!

Thank you for your great work!



